### PR TITLE
Switch to rasterio>=1.0a10 usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.6.0
+
+- Rasterio 1.0 dependency

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,6 @@ dependencies:
 
     pre:
         - pip install tox tox-pyenv
-        - sudo apt-get -y --no-install-recommends --force-yes install libgdal1h gdal-bin libgdal-dev
 
     override:
         - pyenv local 2.7.10 3.6.1

--- a/nodata/blob.py
+++ b/nodata/blob.py
@@ -5,6 +5,7 @@ from numbers import Number
 
 import rasterio as rio
 from rasterio.fill import fillnodata
+from rasterio.windows import Window
 import riomucho
 
 from scipy.ndimage.filters import maximum_filter, minimum_filter

--- a/nodata/blob.py
+++ b/nodata/blob.py
@@ -48,8 +48,8 @@ def blob_worker(srcs, window, ij, globalArgs):
 
     pad = globalArgs['max_search_distance'] + 1
 
-    padWindow = pad_window(window, pad)
-
+    padWindow = Window.from_slices(*pad_window(window, pad))
+    
     img = srcs[0].read(boundless=True, window=padWindow)
 
     if isinstance(globalArgs['selectNodata'], Number):

--- a/nodata/blob.py
+++ b/nodata/blob.py
@@ -53,7 +53,7 @@ def blob_worker(srcs, window, ij, globalArgs):
 
     pad = globalArgs['max_search_distance'] + 1
     padded = pad_window(window, pad)
-    padWindow = Window.from_slices(*padded)
+    padWindow = Window.from_slices(*padded, boundless=True)
     img = srcs[0].read(boundless=True, window=padWindow)
 
     if isinstance(globalArgs['selectNodata'], Number):

--- a/nodata/scripts/alpha.py
+++ b/nodata/scripts/alpha.py
@@ -106,6 +106,6 @@ class NodataPoolMan:
 
             out_data = numpy.fromstring(
                         zlib.decompress(data), self.dtype).reshape(
-                            [int(x) for x in rasterio.window_shape(out_window)])
+                            [int(x) for x in rasterio.windows.shape(out_window)])
 
             yield out_window, out_data

--- a/nodata/scripts/alpha.py
+++ b/nodata/scripts/alpha.py
@@ -95,7 +95,7 @@ class NodataPoolMan:
     def mask(self, windows, **kwargs):
         """Iterate over windows and compute mask arrays.
 
-        The keyword arguments will be passed as keyword arguments to the 
+        The keyword arguments will be passed as keyword arguments to the
         manager's mask algorithm function.
 
         Yields window, ndarray pairs.
@@ -103,6 +103,9 @@ class NodataPoolMan:
         iterargs = izip(windows, repeat(self.nodata), repeat(kwargs))
         for out_window, data in self.pool.imap_unordered(
                 compute_window_mask, iterargs):
-            yield out_window, numpy.fromstring(
+
+            out_data = numpy.fromstring(
                         zlib.decompress(data), self.dtype).reshape(
                             [int(x) for x in rasterio.window_shape(out_window)])
+
+            yield out_window, out_data

--- a/nodata/scripts/alpha.py
+++ b/nodata/scripts/alpha.py
@@ -104,5 +104,5 @@ class NodataPoolMan:
         for out_window, data in self.pool.imap_unordered(
                 compute_window_mask, iterargs):
             yield out_window, numpy.fromstring(
-                                zlib.decompress(data), self.dtype).reshape(
-                                    rasterio.window_shape(out_window))
+                        zlib.decompress(data), self.dtype).reshape(
+                            [int(x) for x in rasterio.window_shape(out_window)])

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with codecs_open('README.rst', encoding='utf-8') as f:
 
 
 setup(name='nodata',
-      version='0.4.2',
+      version='0.5.0',
       description=u"Utilities for handling nodata",
       long_description=long_description,
       classifiers=[],
@@ -22,7 +22,7 @@ setup(name='nodata',
       zip_safe=False,
       install_requires=[
           'click',
-          'rasterio',
+          'rasterio>=1.0a10',
           'rio-mucho',
           'scipy',
           'raster-tester'

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with codecs_open('README.rst', encoding='utf-8') as f:
 
 
 setup(name='nodata',
-      version='0.5.0',
+      version='0.6.0',
       description=u"Utilities for handling nodata",
       long_description=long_description,
       classifiers=[],
@@ -22,10 +22,11 @@ setup(name='nodata',
       zip_safe=False,
       install_requires=[
           'click',
-          'rasterio>=1.0a10',
+          'raster-tester',
+          'rasterio>=1.0a12',
           'rio-mucho',
-          'scipy',
-          'raster-tester'
+          'scikit-image',
+          'scipy'
       ],
       extras_require={
           'test': ['pytest', 'pytest-cov'],

--- a/tests/make_testing_data.py
+++ b/tests/make_testing_data.py
@@ -5,9 +5,20 @@ import click
 
 
 def makehappytiff(dst_path, seams_path):
-    kwargs = {'count': 4, 'crs': {'init': u'epsg:3857'}, 'dtype': 'uint8', 'affine': Affine(4.595839562240513, 0.0, -13550756.3744,
-       0.0, -4.595839562240513, 6315533.02503), 'driver': u'GTiff', 'transform': Affine(4.595839562240513, 0.0, -13550756.3744,
-       0.0, -4.595839562240513, 6315533.02503), 'height': 1065, 'width': 1065, 'nodata': None, 'compress': 'lzw', 'blockxsize': 256, 'tiled': True, 'blockysize': 256}
+    kwargs = {
+        'blockxsize': 256,
+        'blockysize': 256,
+        'compress': 'lzw',
+        'count': 4,
+        'crs': {'init': u'epsg:3857'},
+        'driver': u'GTiff',
+        'dtype': 'uint8',
+        'height': 1065,
+        'nodata': None,
+        'tiled': True,
+        'transform': Affine(4.595839562240513, 0.0, -13550756.3744, 0.0, -4.595839562240513, 6315533.02503),
+        'width': 1065}
+
     imsize = 1065
     testdata = [(np.random.rand(imsize,imsize)*255).astype(np.uint8) for i in range(4)]
     

--- a/tests/test_alpha_func.py
+++ b/tests/test_alpha_func.py
@@ -12,28 +12,16 @@ def image_reader(path):
         return src.read()
 
 
-def test_cases():
-    testdir = 'tests/fixtures/alpha_unit'
-    images = [os.path.join(testdir, i) for i in os.listdir(testdir)
-              if re.compile('.*.tif').match(i.lower())]
-
-    testdir = 'tests/expected/alpha_simple'
-    expected = [os.path.join(testdir, i) for i in os.listdir(testdir)
-                if re.compile('.*.tif').match(i.lower())]
-
-    args = [
-        (0, 0, 0),
-        (0, 0, 0),
-        (255, 255, 255),
-        (0, 0, 0),
-        (255, 255, 255)]
-
-    assert len(args) == len(images) == len(expected)
-    return zip(images, expected, args)
-
-
 @pytest.mark.parametrize(
-    'path, expected, args', test_cases())
+    'path, expected, args',
+    (
+        ('tests/fixtures/alpha_unit/window-1.tif', 'tests/expected/alpha_simple/window-1.tif', (0, 0, 0)),
+        ('tests/fixtures/alpha_unit/window-2.tif', 'tests/expected/alpha_simple/window-2.tif', (0, 0, 0)),
+        ('tests/fixtures/alpha_unit/window-3.tif', 'tests/expected/alpha_simple/window-3.tif', (255, 255, 255)),
+        ('tests/fixtures/alpha_unit/window-4.tif', 'tests/expected/alpha_simple/window-4.tif', (0, 0, 0)),
+        ('tests/fixtures/alpha_unit/window-5.tif', 'tests/expected/alpha_simple/window-5.tif', (255, 255, 255))
+    )
+)
 def test_runner(path, expected, args):
     img = image_reader(path)
     depth, rows, cols = img.shape

--- a/tests/test_alpha_func.py
+++ b/tests/test_alpha_func.py
@@ -32,8 +32,7 @@ def test_runner(path, expected, args):
     expectedImg = image_reader(expected)
 
     assert outputImg.shape == expectedImg.shape
-    assert np.array_equal(outputImg[3], expectedImg[3])  # alpha bands equal
-    # assert np.array_equal(outputImg, expectedImg)
+    assert np.array_equal(outputImg, expectedImg)
 
 
 def test_alphamask_good_alphaonly():

--- a/tests/test_blob_cli.py
+++ b/tests/test_blob_cli.py
@@ -187,7 +187,7 @@ def test_blob_fail_no_nodata():
 
     with rio.open(infile) as src:
         options = src.meta.copy()
-        options.update(nodata=None, transform=src.affine)
+        options.update(nodata=None)
 
         with rio.open(badfile, 'w', **options) as dst:
             dst.write(src.read())

--- a/tests/test_scripts_alpha.py
+++ b/tests/test_scripts_alpha.py
@@ -34,7 +34,7 @@ def test_compute_window_mask(worker):
     assert in_window == out_window
     assert (numpy.fromstring(
         zlib.decompress(data), 'uint8').reshape(
-            rasterio.window_shape(out_window)) == 255).all()
+            [int(c) for c in rasterio.window_shape(out_window)]) == 255).all()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_scripts_alpha.py
+++ b/tests/test_scripts_alpha.py
@@ -35,7 +35,7 @@ def test_compute_window_mask(worker):
     assert in_window == out_window
     assert (numpy.fromstring(
         zlib.decompress(data), 'uint8').reshape(
-            [int(c) for c in rasterio.window_shape(out_window)]) == 255).all()
+            [int(c) for c in rasterio.windows.shape(out_window)]) == 255).all()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_scripts_alpha.py
+++ b/tests/test_scripts_alpha.py
@@ -4,6 +4,7 @@ import zlib
 import numpy
 import pytest
 import rasterio
+from rasterio.windows import Window
 
 from nodata.scripts.alpha import (
     all_valid, init_worker, finalize_worker, compute_window_mask,
@@ -29,7 +30,7 @@ def worker(request):
 
 def test_compute_window_mask(worker):
     """Get an all-valid mask for one window"""
-    in_window = ((0, 100), (0, 100))
+    in_window = Window.from_slices((0, 100), (0, 100))
     out_window, data = compute_window_mask((in_window, 0, {}))
     assert in_window == out_window
     assert (numpy.fromstring(
@@ -44,9 +45,9 @@ def test_pool_man_mask(input_path):
     manager = NodataPoolMan(input_path, all_valid, 0)
     assert manager.input_path == input_path
     assert manager.nodata == 0
-    result = manager.mask(windows=[((0, 100), (0, 100))])
+    result = manager.mask(windows=[Window.from_slices((0, 100), (0, 100))])
     window, arr = next(result)
-    assert window == ((0, 100), (0, 100))
+    assert window == Window.from_slices((0, 100), (0, 100))
     assert (arr == 255).all()
     with pytest.raises(StopIteration):
         next(result)
@@ -58,9 +59,9 @@ def test_pool_man_mask_keywords(keywords):
     """NodataPoolMan initializes and computes mask of a file"""
     manager = NodataPoolMan(
         'tests/fixtures/alpha/lossy-curved-edges.tif', all_valid, 0)
-    result = manager.mask(windows=[((0, 100), (0, 100))], **keywords)
+    result = manager.mask(windows=[Window.from_slices((0, 100), (0, 100))], **keywords)
     window, arr = next(result)
-    assert window == ((0, 100), (0, 100))
+    assert window == Window.from_slices((0, 100), (0, 100))
     assert (arr == 255).all()
     with pytest.raises(StopIteration):
         next(result)

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py27,py36
 [testenv]
 commands=py.test -vv --cov nodata --cov-report term-missing --ignore=venv
 deps=
-    rasterio>=1.0a8
+    rasterio>=1.0a12
     click
     codecov
     numpy


### PR DESCRIPTION
Avoids deprecation warnings with rasterio>=1.0a10.

Not urgent, @dnomadb, but I wanted to hit this while it was staring me in the face.